### PR TITLE
Fix Vulkan-only build with GLFW

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 // src/main.cpp
 #define GLFW_INCLUDE_VULKAN
+#define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 
 #include <algorithm>


### PR DESCRIPTION
## Summary
- avoid including GL headers when Vulkan is used by defining `GLFW_INCLUDE_NONE`

## Testing
- `cmake .. -GNinja -DGLFW_BUILD_WAYLAND=OFF`
- `ninja`
- `./Metharizon` *(runs headless in this container)*


------
https://chatgpt.com/codex/tasks/task_e_6887dfc3bcf083219353e91e798ab6c7