### PR TITLE
Fix headless window detection on Windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -183,7 +183,7 @@ void pickPhysicalDevice() {
 void createInstance() {
     const char* displayEnv = getenv("DISPLAY");
     const char* wlDisplayEnv = getenv("WAYLAND_DISPLAY");
-#ifdef GLFW_PLATFORM_NULL
+#if defined(__linux__) && defined(GLFW_PLATFORM_NULL)
     if ((!displayEnv || !*displayEnv) && (!wlDisplayEnv || !*wlDisplayEnv)) {
         glfwInitHint(GLFW_PLATFORM, GLFW_PLATFORM_NULL);
         headless = true;


### PR DESCRIPTION
## Summary
- fix incorrect headless detection on Windows

## Testing
- `cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ..`
- `ninja`

------
https://chatgpt.com/codex/tasks/task_e_6887e95c66788321abd2908418db23c5