### PR TITLE
Fix compute shader compilation errors

### DIFF
--- a/shaders/comp.glsl
+++ b/shaders/comp.glsl
@@ -36,7 +36,6 @@ float sierpinski(vec3 p){
         if(p.y < p.z) p.yz = p.zy;
         p = SCALE * p - (SCALE - 1.0) * OFFSET;
         m *= SCALE;
-main
     }
     return length(p)/m - 0.1;
 }
@@ -46,7 +45,6 @@ float objectDE(int idx, vec3 p){
     float r = objs.posRad[idx].w;
 
     return sierpinski(lp / r) * r;
-main
 }
 
 float sceneDE(vec3 p){


### PR DESCRIPTION
## Summary
- remove stray `main` tokens from compute shader

## Testing
- `cmake -S . -B build -DGLFW_BUILD_WAYLAND=OFF`
- `cmake --build build -j 2`


------
https://chatgpt.com/codex/tasks/task_e_6887f94e1d98832184e942c184829637