### PR TITLE
Fix build by disabling Wayland

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ FetchContent_Declare(
 set(GLFW_BUILD_DOCS     OFF CACHE BOOL "" FORCE)
 set(GLFW_BUILD_TESTS    OFF CACHE BOOL "" FORCE)
 set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(GLFW_BUILD_WAYLAND OFF CACHE BOOL "" FORCE)
+set(GLFW_BUILD_X11     ON  CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(glfw)
 
 # 3) find your Vulkan SDK on the system


### PR DESCRIPTION
## Summary
- disable Wayland backend when building GLFW so we only depend on X11

## Testing
- `cmake -DVulkan_GLSLC_EXECUTABLE=/usr/bin/glslc ..`
- `make -j$(nproc)`
- `./Metharizon --headless`


------
https://chatgpt.com/codex/tasks/task_e_6887fb089d948321ae5d0b2141d6df92