### PR TITLE
Increase fractal size

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1043,7 +1043,7 @@ int main() {
             {0.f,0.f,0.f},  // velocity
             {0.f,0.5f,0.f},  // angular velocity
             {1.f,0.f,0.f,0.f}, // orientation
-            fracRad,
+            fracRad * 50.f,
             1.f,  // mass
             0.4f, // inertia
             sierpinskiDE
@@ -1053,7 +1053,7 @@ int main() {
             {0.f,0.f,0.f},
             {0.f,-0.5f,0.f},
             {1.f,0.f,0.f,0.f},
-            fracRad,
+            fracRad * 50.f,
             1.f,
             0.4f,
             sierpinskiDE


### PR DESCRIPTION
## Summary
- make the Sierpiński tetrahedra visible by scaling their radius by 50x

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_688811f4b0388321acf26f1fb885653a