### PR TITLE
Fix fractal scale and improve visibility

### DIFF
--- a/shaders/comp.glsl
+++ b/shaders/comp.glsl
@@ -86,14 +86,16 @@ void main(){
 
     vec3 col;
     if(t > MAXT) {
-        col = vec3(0.0);
+        // white background so fractals stand out
+        col = vec3(1.0);
     } else {
         vec3 p = ro + rd*t;
         vec3 n = sceneNormal(p);
-        // simple side lighting
+        // side lighting with pink base color
         vec3 lightDir = normalize(vec3(1.0, 1.0, 0.5));
         float diff = clamp(dot(n, lightDir), 0.0, 1.0);
-        col = mix(vec3(0.1,0.1,0.2), vec3(0.6,0.8,1.0), diff);
+        vec3 base = vec3(1.0, 0.0, 1.0);
+        col = mix(base * 0.2, base, diff);
     }
 
     imageStore(img, uv, vec4(col,1.0));

--- a/src/physics.h
+++ b/src/physics.h
@@ -97,14 +97,11 @@ inline float sierpinskiDE(Vec3 p){
     return length(p)/m;
 }
 
+// The DE never becomes negative along the x axis so the bisection search above
+// converged towards zero, resulting in a near‑zero radius. The Sierpiński
+// tetrahedron comfortably fits in a unit sphere, so just return 1.
 inline float estimateSierpinskiRadius(){
-    float lo = 0.0f, hi = 2.0f;
-    for(int i=0;i<32;i++){
-        float mid = (lo + hi) * 0.5f;
-        float d = sierpinskiDE(Vec3{mid,0.f,0.f});
-        if(d>0.f) hi = mid; else lo = mid;
-    }
-    return hi;
+    return 1.0f;
 }
 
 inline void integrateOrientation(FractalObject& obj, float dt){


### PR DESCRIPTION
## Summary
- recolor compute shader: fractals now pink on a white background
- fix `estimateSierpinskiRadius` which previously returned almost zero

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68881399aa7c8321947337c1097b5e06