### PR TITLE
Improve object collision handling

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -767,8 +767,9 @@ int main() {
         rotateVec(camRot, BASE_UP,      cam.up);
         rotateVec(camRot, BASE_RIGHT,   cam.right);
 
-        FractalObject objA{{-2.f,0.f,0.f},{0.f,0.f,0.f},1.f,1.f};
-        FractalObject objB{{ 2.f,0.f,0.f},{0.f,0.f,0.f},1.f,1.f};
+        // Increase radius so the bounding sphere encloses the fractal
+        FractalObject objA{{-2.f,0.f,0.f},{0.f,0.f,0.f},2.f,1.f};
+        FractalObject objB{{ 2.f,0.f,0.f},{0.f,0.f,0.f},2.f,1.f};
 
         double lastX = WIDTH/2.0, lastY = HEIGHT/2.0;
         glfwSetCursorPos(window, lastX, lastY);

--- a/src/physics.h
+++ b/src/physics.h
@@ -52,6 +52,8 @@ inline void stepPhysics(FractalObject& a, FractalObject& b, float dt, float G=1.
     Vec3 force = n * forceMag;
     a.velocity = a.velocity + force / a.mass * dt;
     b.velocity = b.velocity - force / b.mass * dt;
+
+    // integrate positions
     a.position = a.position + a.velocity * dt;
     b.position = b.position + b.velocity * dt;
     if(dist <= a.radius + b.radius){
@@ -59,6 +61,12 @@ inline void stepPhysics(FractalObject& a, FractalObject& b, float dt, float G=1.
         float da = mandelbulbDE(mid - a.position);
         float db = mandelbulbDE(mid - b.position);
         if(da < 0.001f && db < 0.001f){
+            // positional correction to avoid sinking
+            float penetration = a.radius + b.radius - dist;
+            Vec3 correction = (penetration > 0.0f) ? n * (penetration * 0.5f) : Vec3{0,0,0};
+            a.position = a.position - correction;
+            b.position = b.position + correction;
+
             float rel = dot(b.velocity - a.velocity, n);
             if(rel < 0.0f){
                 float j = -(1.0f + 1.0f) * rel / (1.0f/a.mass + 1.0f/b.mass);


### PR DESCRIPTION
## Summary
- adjust object radius to fully enclose Mandelbulb
- add positional correction when objects collide

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_688840bb64e883218d6f9062d9532748