### PR TITLE
Improve fractal probe accuracy

### DIFF
--- a/shaders/comp.glsl
+++ b/shaders/comp.glsl
@@ -32,7 +32,7 @@ float mandelbulb(vec3 p) {
     vec3 z = p;
     float dr = 1.0;
     float r  = 0.0;
-    const int ITER = 8;
+    const int ITER = 12;
     for(int i=0;i<ITER;i++){
         r = length(z);
         if(r>2.0) break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -588,9 +588,15 @@ void drawFrame(uint32_t /*unused*/, Camera &cam,
     Vec3 diff = objB.position - objA.position;
     Vec3 n    = normalize(diff);
     Vec3 cA   = objA.position + n * objA.radius;
-    Vec3 cB   = objB.position - n * objB.radius;
     float rA  = mandelbulbDE(cA - objA.position);
+    cA = cA - n * rA;
+    rA  = mandelbulbDE(cA - objA.position);
+
+    Vec3 cB   = objB.position - n * objB.radius;
     float rB  = mandelbulbDE(cB - objB.position);
+    cB = cB + n * rB;
+    rB  = mandelbulbDE(cB - objB.position);
+
     std::memcpy(objs.probe0, &cA, sizeof(float)*3);
     objs.probe0[3] = rA;
     std::memcpy(objs.probe1, &cB, sizeof(float)*3);

--- a/src/physics.h
+++ b/src/physics.h
@@ -25,7 +25,7 @@ inline float mandelbulbDE(Vec3 p){
     Vec3 z = p;
     float dr = 1.0f;
     float r  = 0.0f;
-    const int ITER = 8;
+    const int ITER = 12;
     for(int i=0;i<ITER;i++){
         r = length(z);
         if(r>2.0f) break;


### PR DESCRIPTION
## Summary
- refine probe sphere placement by stepping towards the mandelbulb surface
- increase DE iterations for better precision

## Testing
- `cmake ..`
- `make -j2`


------
https://chatgpt.com/codex/tasks/task_e_6888bfa0b13c8321a4e417a199b42380